### PR TITLE
fix: migrate legacy keyblob versions

### DIFF
--- a/src/keymaster/db.rs
+++ b/src/keymaster/db.rs
@@ -993,9 +993,13 @@ pub struct SupersededBlob {
 
 impl KeystoreDB {
     const UNASSIGNED_KEY_ID: i64 = -1i64;
-    const CURRENT_DB_VERSION: u32 = 3;
-    const UPGRADERS: &'static [fn(&Transaction) -> Result<u32>] =
-        &[Self::from_0_to_1, Self::from_1_to_2, Self::from_2_to_3];
+    const CURRENT_DB_VERSION: u32 = 4;
+    const UPGRADERS: &'static [fn(&Transaction) -> Result<u32>] = &[
+        Self::from_0_to_1,
+        Self::from_1_to_2,
+        Self::from_2_to_3,
+        Self::from_3_to_4,
+    ];
 
     /// Name of the file that holds the cross-boot persistent database.
     pub const PERSISTENT_DB_FILENAME: &'static str = "keymaster.db";
@@ -1229,6 +1233,22 @@ impl KeystoreDB {
 
         // DB version is now 3.
         Ok(3)
+    }
+
+    // Normalize legacy OS versions cached from KeyMint key characteristics.
+    fn from_3_to_4(tx: &Transaction) -> Result<u32> {
+        let updated = tx
+            .execute(
+                "UPDATE persistent.keyparameter
+                 SET data = data * 10000
+                 WHERE tag = ? AND data >= 0 AND data < 100;",
+                params![Tag::OS_VERSION.0],
+            )
+            .context(ks_err!("Failed to normalize legacy OS versions"))?;
+        info!("normalized {updated} legacy OS version key parameters");
+
+        // DB version is now 4.
+        Ok(4)
     }
 
     fn init_tables(tx: &Transaction) -> Result<()> {
@@ -3853,6 +3873,18 @@ mod tests {
                 VALUES (10, 0, 1, X'01'), (11, 0, 1, X'02');"
         ))
         .unwrap();
+        conn.execute(
+            "INSERT INTO persistent.keyparameter
+             (keyentryid, tag, data, security_level)
+             VALUES (1, ?, 16, ?), (1, ?, 16, ?);",
+            params![
+                Tag::OS_VERSION.0,
+                SecurityLevel::TRUSTED_ENVIRONMENT.0,
+                Tag::OS_PATCHLEVEL.0,
+                SecurityLevel::TRUSTED_ENVIRONMENT.0,
+            ],
+        )
+        .unwrap();
         conn
     }
 
@@ -4013,7 +4045,7 @@ mod tests {
             }
 
             assert_eq!(
-                3,
+                4,
                 conn.query_row(
                     "SELECT version FROM persistent.version WHERE id = 0;",
                     [],
@@ -4036,6 +4068,24 @@ mod tests {
                     "SELECT state FROM persistent.blobentry WHERE id = 11;",
                     [],
                     |row| row.get::<_, BlobState>(0),
+                )
+                .unwrap()
+            );
+            assert_eq!(
+                160000,
+                conn.query_row(
+                    "SELECT data FROM persistent.keyparameter WHERE tag = ?;",
+                    params![Tag::OS_VERSION.0],
+                    |row| row.get::<_, i32>(0),
+                )
+                .unwrap()
+            );
+            assert_eq!(
+                16,
+                conn.query_row(
+                    "SELECT data FROM persistent.keyparameter WHERE tag = ?;",
+                    params![Tag::OS_PATCHLEVEL.0],
+                    |row| row.get::<_, i32>(0),
                 )
                 .unwrap()
             );

--- a/ta/src/keys.rs
+++ b/ta/src/keys.rs
@@ -822,14 +822,17 @@ impl crate::KeyMintTa {
                 }
                 Ordering::Equal => Ok(false),
                 Ordering::Greater => {
-                    error!("refusing to downgrade {name} from {v} to {curr}");
-                    Err(km_err!(
-                        InvalidArgument,
-                        "keyblob with future {} {} (current {})",
-                        name,
-                        v,
-                        curr
-                    ))
+                    // We allow patchlevel downgrades.
+                    // error!("refusing to downgrade {name} from {v} to {curr}");
+                    // Err(km_err!(
+                    //     InvalidArgument,
+                    //     "keyblob with future {} {} (current {})",
+                    //     name,
+                    //     v,
+                    //     curr
+                    // ))
+                    *v = curr;
+                    Ok(true)
                 }
             }
         }


### PR DESCRIPTION
## What changed and why?

Fix KeyMint startup with legacy keyblobs after the OS version encoding changed from values such as `16` to `160000`.

- Bump the keymaster database from v3 to v4.
- During the v3-to-v4 migration, multiply persisted `OS_VERSION` values in `[0, 100)` by `10000`.
- Allow the existing `upgradeKey` path to lower future patchlevels to the current values so the TA can decrypt, update, and rewrap affected keyblobs.

Regression observed after: https://github.com/qwq233/OhMyKeymint/actions/runs/30481734829

## Behavior and risk

- The database migration changes only legacy `OS_VERSION` rows; `OS_PATCHLEVEL` and other key parameters remain unchanged.
- Keyblob contents are not edited directly in the database. The existing TA upgrade path performs authenticated decrypt/update/rewrap.
- `upgradeKey` now permits OS, vendor, and boot patchlevel downgrades when a keyblob contains a value newer than the current runtime value. This intentionally weakens the previous rollback check.
- No documentation, configuration schema, or `main.rs` behavior is changed.

## Validation

- `git diff --check`: passed.
- Fork GitHub Actions `Build OhMyKeymint` workflow (BoringSSL, debug, and release Android builds): passed ([run 30990507701](https://github.com/947409161/OhMyKeymint/actions/runs/30990507701)).
- Added database migration coverage for both legacy `blobentry` schema variants, including verification that `OS_VERSION 16` becomes `160000` while `OS_PATCHLEVEL 16` is unchanged.
- Full Android Rust gate not run locally: this environment has no `cargo`, `rustc`, `rustfmt`, or Android Rust toolchain. The successful workflow builds the Android target but does not run all three required fmt/clippy/test gate commands.
- On-device test binaries not run: this environment has no authorized aarch64 Android device or `adb`.

- [ ] The Android Rust gate passed, or this is a documentation-only change.
- [ ] All generated test binaries ran on an aarch64 Android device, or the
      reason this gate was not run is stated above.

## Checklist

- [x] I checked for and reused existing methods, helpers, abstractions,
      configuration, and utilities.
- [x] This pull request contains no unrelated changes or force-added ignored files.
- [x] I did not use `#[allow(...)]` only to silence Clippy.
- [x] I disclosed third-party material, its source, and its license, and kept all
      required notices.
- [x] I have read and agree to the copyright, concurrent-license, dispute
      authorization, and relicensing terms in
      [CONTRIBUTING.md](https://github.com/qwq233/OhMyKeymint/blob/master/docs/CONTRIBUTING.md).
