### PR TITLE
fix: make auth token mirrors loss-tolerant

### DIFF
--- a/injector/src/hook/rewrite/mirror.rs
+++ b/injector/src/hook/rewrite/mirror.rs
@@ -14,6 +14,12 @@ pub(super) enum MirrorStateKind {
     Maintenance,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MirrorFailurePolicy {
+    BestEffort,
+    FailClosed,
+}
+
 #[derive(Clone)]
 enum MirrorReplayEvent {
     Authorization {
@@ -36,6 +42,7 @@ struct SequencedMirrorReplay {
 
 pub(super) struct MirrorUpdateReservation {
     kind: MirrorStateKind,
+    failure_policy: MirrorFailurePolicy,
     sequence: u64,
     active: bool,
 }
@@ -140,6 +147,13 @@ impl MirrorReplayEvent {
         }
     }
 
+    fn failure_policy(&self) -> MirrorFailurePolicy {
+        match self {
+            Self::Authorization { request, .. } => authorization_mirror_failure_policy(request),
+            Self::Maintenance { .. } => MirrorFailurePolicy::FailClosed,
+        }
+    }
+
     fn execute(&self) -> anyhow::Result<()> {
         match self {
             Self::Authorization { request, caller } => {
@@ -156,6 +170,18 @@ pub(super) fn authorization_requires_mirror(request: &ParsedAuthorizationRequest
         ParsedAuthorizationRequest::GetAuthTokensForCredStore { .. }
             | ParsedAuthorizationRequest::GetLastAuthTime { .. }
     )
+}
+
+pub(super) fn authorization_mirror_failure_policy(
+    request: &ParsedAuthorizationRequest,
+) -> MirrorFailurePolicy {
+    // AddAuthToken only feeds per-boot cached state and a later authentication replenishes it.
+    // Lock and user-state notifications must remain ordered and fail-closed.
+    if matches!(request, ParsedAuthorizationRequest::AddAuthToken { .. }) {
+        MirrorFailurePolicy::BestEffort
+    } else {
+        MirrorFailurePolicy::FailClosed
+    }
 }
 
 pub(super) fn maintenance_requires_mirror(request: &ParsedMaintenanceRequest) -> bool {
@@ -204,6 +230,7 @@ fn remove_reserved_mirror_update(
 
 pub(super) fn reserve_mirror_update(
     kind: MirrorStateKind,
+    failure_policy: MirrorFailurePolicy,
 ) -> anyhow::Result<MirrorUpdateReservation> {
     let mut state = MIRROR_RECOVERY_STATE
         .lock()
@@ -232,6 +259,7 @@ pub(super) fn reserve_mirror_update(
         });
     Ok(MirrorUpdateReservation {
         kind,
+        failure_policy,
         sequence,
         active: true,
     })
@@ -240,31 +268,43 @@ pub(super) fn reserve_mirror_update(
 impl MirrorUpdateReservation {
     fn enqueue(mut self, event: MirrorReplayEvent) -> anyhow::Result<()> {
         debug_assert_eq!(event.kind(), self.kind);
+        debug_assert_eq!(event.failure_policy(), self.failure_policy);
         let method = event.method();
         let caller_uid = event.caller().uid;
         let caller_pid = event.caller().pid;
         let mut state = MIRROR_RECOVERY_STATE
             .lock()
             .expect("mirror recovery state poisoned");
-        let Some(pending) = state
-            .lane_mut(self.kind)
+        let Some(position) = state
+            .lane(self.kind)
             .pending
-            .iter_mut()
-            .find(|pending| pending.sequence == self.sequence)
+            .iter()
+            .position(|pending| pending.sequence == self.sequence)
         else {
-            poison_mirror_state(&mut state, self.kind);
+            if self.failure_policy == MirrorFailurePolicy::FailClosed {
+                poison_mirror_state(&mut state, self.kind);
+            }
             self.active = false;
             drop(state);
             wake_mirror_recovery_worker();
             anyhow::bail!("mirror update reservation disappeared");
         };
-        if pending.kind != self.kind || pending.event.is_some() {
-            poison_mirror_state(&mut state, self.kind);
+        let reservation_changed = {
+            let pending = &state.lane(self.kind).pending[position];
+            pending.kind != self.kind || pending.event.is_some()
+        };
+        if reservation_changed {
+            if self.failure_policy == MirrorFailurePolicy::FailClosed {
+                poison_mirror_state(&mut state, self.kind);
+            } else {
+                remove_reserved_mirror_update(&mut state, self.kind, self.sequence);
+            }
             self.active = false;
             drop(state);
             wake_mirror_recovery_worker();
             anyhow::bail!("mirror update reservation changed unexpectedly");
         }
+        let pending = &mut state.lane_mut(self.kind).pending[position];
         pending.event = Some(event);
         pending.retry_not_before = None;
         let pending = state.pending_len();
@@ -303,13 +343,22 @@ impl Drop for MirrorUpdateReservation {
             .lock()
             .expect("mirror recovery state poisoned");
         remove_reserved_mirror_update(&mut state, self.kind, self.sequence);
-        poison_mirror_state(&mut state, self.kind);
+        if self.failure_policy == MirrorFailurePolicy::FailClosed {
+            poison_mirror_state(&mut state, self.kind);
+        }
         self.active = false;
         drop(state);
-        warn!(
-            "event=mirror {} update lost its System reply; OMK routes are fail-closed until process restart",
-            self.kind.label()
-        );
+        if self.failure_policy == MirrorFailurePolicy::FailClosed {
+            warn!(
+                "event=mirror {} update lost its System reply; OMK routes are fail-closed until process restart",
+                self.kind.label()
+            );
+        } else {
+            warn!(
+                "event=mirror {} best-effort update lost its System reply; dropping the mirror without blocking OMK routes",
+                self.kind.label()
+            );
+        }
         wake_mirror_recovery_worker();
     }
 }
@@ -370,6 +419,7 @@ fn recover_mirror_state_with(
             .as_ref()
             .expect("ready mirror replay lost its event");
         let method = event.method();
+        let failure_policy = event.failure_policy();
         let result = execute(event);
         let mut state = MIRROR_RECOVERY_STATE
             .lock()
@@ -402,6 +452,22 @@ fn recover_mirror_state_with(
                     pending.sequence,
                     pending.kind.label(),
                     method,
+                    remaining
+                );
+                wake_mirror_recovery_worker();
+            }
+            Err(error) if failure_policy == MirrorFailurePolicy::BestEffort => {
+                let lane = state.lane_mut(pending.kind);
+                lane.pending.pop_front();
+                lane.draining = false;
+                let remaining = state.pending_len();
+                drop(state);
+                warn!(
+                    "event=mirror replay sequence={} domain={} method={} failed: {:#}; dropping best-effort event and continuing; pending={}",
+                    pending.sequence,
+                    pending.kind.label(),
+                    method,
+                    error,
                     remaining
                 );
                 wake_mirror_recovery_worker();
@@ -520,12 +586,26 @@ pub(super) unsafe fn build_authorization_reply_mirror(
         request: call.request.clone(),
         caller: call.caller.clone(),
     };
-    let reservation = call
-        .mirror_update
-        .take()
-        .ok_or_else(|| anyhow::anyhow!("authorization mirror reservation is missing"))?;
+    let failure_policy = event.failure_policy();
+    let Some(reservation) = call.mirror_update.take() else {
+        if failure_policy == MirrorFailurePolicy::BestEffort {
+            warn!(
+                "event=mirror domain=authorization no queue reservation for best-effort {:?} uid={} pid={}; preserving System success without an OMK mirror",
+                method, call.caller.uid, call.caller.pid
+            );
+            return Ok(None);
+        }
+        anyhow::bail!("authorization mirror reservation is missing");
+    };
     match reservation.enqueue(event) {
         Ok(()) => Ok(None),
+        Err(error) if failure_policy == MirrorFailurePolicy::BestEffort => {
+            warn!(
+                "event=mirror domain=authorization failed to queue best-effort {:?} for OMK for uid={} pid={}: {:#}; preserving System success",
+                method, call.caller.uid, call.caller.pid, error
+            );
+            Ok(None)
+        }
         Err(error) => {
             warn!(
                 "event=mirror domain=authorization failed to queue {:?} for OMK for uid={} pid={}: {:#}",

--- a/injector/src/hook/rewrite/mirror/tests/mod.rs
+++ b/injector/src/hook/rewrite/mirror/tests/mod.rs
@@ -10,31 +10,40 @@ fn mirror_recovery_retries_sensitive_events_in_global_sequence() {
         pid: 2000,
     };
 
-    reserve_mirror_update(MirrorStateKind::Maintenance)
-        .expect("onUserAdded should reserve")
-        .enqueue(MirrorReplayEvent::Maintenance {
-            request: ParsedMaintenanceRequest::OnUserAdded { user_id: 10 },
-            caller: caller.clone(),
-        })
-        .expect("onUserAdded should queue");
-    reserve_mirror_update(MirrorStateKind::Maintenance)
-        .expect("initUserSuperKeys should reserve")
-        .enqueue(MirrorReplayEvent::Maintenance {
-            request: ParsedMaintenanceRequest::InitUserSuperKeys {
-                user_id: 10,
-                password: vec![1, 2, 3],
-                allow_existing: false,
-            },
-            caller: caller.clone(),
-        })
-        .expect("initUserSuperKeys should queue");
-    reserve_mirror_update(MirrorStateKind::Authorization)
-        .expect("onUserStorageLocked should reserve")
-        .enqueue(MirrorReplayEvent::Authorization {
-            request: ParsedAuthorizationRequest::OnUserStorageLocked { user_id: 10 },
-            caller: caller.clone(),
-        })
-        .expect("onUserStorageLocked should queue");
+    reserve_mirror_update(
+        MirrorStateKind::Maintenance,
+        MirrorFailurePolicy::FailClosed,
+    )
+    .expect("onUserAdded should reserve")
+    .enqueue(MirrorReplayEvent::Maintenance {
+        request: ParsedMaintenanceRequest::OnUserAdded { user_id: 10 },
+        caller: caller.clone(),
+    })
+    .expect("onUserAdded should queue");
+    reserve_mirror_update(
+        MirrorStateKind::Maintenance,
+        MirrorFailurePolicy::FailClosed,
+    )
+    .expect("initUserSuperKeys should reserve")
+    .enqueue(MirrorReplayEvent::Maintenance {
+        request: ParsedMaintenanceRequest::InitUserSuperKeys {
+            user_id: 10,
+            password: vec![1, 2, 3],
+            allow_existing: false,
+        },
+        caller: caller.clone(),
+    })
+    .expect("initUserSuperKeys should queue");
+    reserve_mirror_update(
+        MirrorStateKind::Authorization,
+        MirrorFailurePolicy::FailClosed,
+    )
+    .expect("onUserStorageLocked should reserve")
+    .enqueue(MirrorReplayEvent::Authorization {
+        request: ParsedAuthorizationRequest::OnUserStorageLocked { user_id: 10 },
+        caller: caller.clone(),
+    })
+    .expect("onUserStorageLocked should queue");
 
     let mut executed = Vec::new();
     let mut fail_sensitive = true;
@@ -121,15 +130,21 @@ fn mirror_reservation_holds_global_order_and_lost_reply_fails_closed() {
         sid: String::new(),
         pid: 2000,
     };
-    let earlier = reserve_mirror_update(MirrorStateKind::Authorization)
-        .expect("authorization update should reserve");
-    reserve_mirror_update(MirrorStateKind::Maintenance)
-        .expect("maintenance update should reserve")
-        .enqueue(MirrorReplayEvent::Maintenance {
-            request: ParsedMaintenanceRequest::OnUserRemoved { user_id: 11 },
-            caller,
-        })
-        .expect("later System reply should publish its event");
+    let earlier = reserve_mirror_update(
+        MirrorStateKind::Authorization,
+        MirrorFailurePolicy::FailClosed,
+    )
+    .expect("authorization update should reserve");
+    reserve_mirror_update(
+        MirrorStateKind::Maintenance,
+        MirrorFailurePolicy::FailClosed,
+    )
+    .expect("maintenance update should reserve")
+    .enqueue(MirrorReplayEvent::Maintenance {
+        request: ParsedMaintenanceRequest::OnUserRemoved { user_id: 11 },
+        caller,
+    })
+    .expect("later System reply should publish its event");
 
     let mut replayed = 0;
     assert!(recover_mirror_state_with(&mut |_| {
@@ -156,8 +171,11 @@ fn mirror_reservation_holds_global_order_and_lost_reply_fails_closed() {
     assert_eq!(replayed, 1);
 
     drop(
-        reserve_mirror_update(MirrorStateKind::Authorization)
-            .expect("lost authorization update should reserve"),
+        reserve_mirror_update(
+            MirrorStateKind::Authorization,
+            MirrorFailurePolicy::FailClosed,
+        )
+        .expect("lost authorization update should reserve"),
     );
     let state = MIRROR_RECOVERY_STATE
         .lock()
@@ -169,7 +187,7 @@ fn mirror_reservation_holds_global_order_and_lost_reply_fails_closed() {
 }
 
 #[test]
-fn full_mirror_queue_rejects_only_the_new_system_mutation() {
+fn full_mirror_queue_rejects_only_the_new_fail_closed_mutation() {
     let _guard = route_state_test_guard();
     let caller = CallerInfo {
         uid: 1000,
@@ -177,16 +195,25 @@ fn full_mirror_queue_rejects_only_the_new_system_mutation() {
         pid: 2000,
     };
     for _ in 0..MAX_PENDING_MIRROR_REPLAYS {
-        reserve_mirror_update(MirrorStateKind::Authorization)
-            .expect("queue slot should reserve")
-            .enqueue(MirrorReplayEvent::Authorization {
-                request: ParsedAuthorizationRequest::OnUserStorageLocked { user_id: 10 },
-                caller: caller.clone(),
-            })
-            .expect("reserved event should queue");
+        reserve_mirror_update(
+            MirrorStateKind::Authorization,
+            MirrorFailurePolicy::FailClosed,
+        )
+        .expect("queue slot should reserve")
+        .enqueue(MirrorReplayEvent::Authorization {
+            request: ParsedAuthorizationRequest::OnUserStorageLocked { user_id: 10 },
+            caller: caller.clone(),
+        })
+        .expect("reserved event should queue");
     }
 
-    assert!(reserve_mirror_update(MirrorStateKind::Authorization).is_err());
+    assert!(
+        reserve_mirror_update(
+            MirrorStateKind::Authorization,
+            MirrorFailurePolicy::FailClosed,
+        )
+        .is_err()
+    );
     assert!(
         !MIRROR_RECOVERY_STATE
             .lock()
@@ -231,8 +258,11 @@ fn non_ok_system_reply_cancels_mirror_reservation() {
             pid: 2000,
         },
         mirror_update: Some(
-            reserve_mirror_update(MirrorStateKind::Authorization)
-                .expect("authorization update should reserve"),
+            reserve_mirror_update(
+                MirrorStateKind::Authorization,
+                MirrorFailurePolicy::BestEffort,
+            )
+            .expect("authorization update should reserve"),
         ),
     };
 
@@ -244,19 +274,149 @@ fn non_ok_system_reply_cancels_mirror_reservation() {
 }
 
 #[test]
+fn best_effort_add_auth_token_failures_do_not_block_later_events() {
+    let _guard = route_state_test_guard();
+    let caller = CallerInfo {
+        uid: 1000,
+        sid: String::new(),
+        pid: 2000,
+    };
+
+    for _ in 0..2 {
+        reserve_mirror_update(
+            MirrorStateKind::Authorization,
+            MirrorFailurePolicy::BestEffort,
+        )
+        .expect("addAuthToken should reserve")
+        .enqueue(MirrorReplayEvent::Authorization {
+            request: ParsedAuthorizationRequest::AddAuthToken {
+                auth_token: Default::default(),
+            },
+            caller: caller.clone(),
+        })
+        .expect("addAuthToken should queue");
+    }
+    reserve_mirror_update(
+        MirrorStateKind::Authorization,
+        MirrorFailurePolicy::FailClosed,
+    )
+    .expect("onUserStorageLocked should reserve")
+    .enqueue(MirrorReplayEvent::Authorization {
+        request: ParsedAuthorizationRequest::OnUserStorageLocked { user_id: 10 },
+        caller,
+    })
+    .expect("onUserStorageLocked should queue");
+
+    let mut attempts = 0;
+    let mut executed = Vec::new();
+    recover_mirror_state_with(&mut |event| {
+        let method = event.method();
+        executed.push(method.clone());
+        if method == "AddAuthToken" {
+            attempts += 1;
+            if attempts == 1 {
+                return Err(anyhow::Error::new(Status::new_service_specific_error(
+                    7, None,
+                )));
+            }
+            return Err(anyhow::Error::new(StatusCode::DeadObject));
+        }
+        Ok(())
+    })
+    .expect("best-effort failures should be dropped and later state should replay");
+
+    assert_eq!(
+        executed,
+        ["AddAuthToken", "AddAuthToken", "OnUserStorageLocked"]
+    );
+    assert!(!mirror_state_dirty(MirrorStateKind::Authorization));
+    assert!(ensure_mirror_state_recovered().is_ok());
+}
+
+#[test]
+fn lost_best_effort_reply_does_not_poison_mirror_state() {
+    let _guard = route_state_test_guard();
+    let caller = CallerInfo {
+        uid: 1000,
+        sid: String::new(),
+        pid: 2000,
+    };
+    let lost = reserve_mirror_update(
+        MirrorStateKind::Authorization,
+        MirrorFailurePolicy::BestEffort,
+    )
+    .expect("addAuthToken should reserve");
+    reserve_mirror_update(
+        MirrorStateKind::Authorization,
+        MirrorFailurePolicy::FailClosed,
+    )
+    .expect("onUserStorageLocked should reserve")
+    .enqueue(MirrorReplayEvent::Authorization {
+        request: ParsedAuthorizationRequest::OnUserStorageLocked { user_id: 10 },
+        caller,
+    })
+    .expect("onUserStorageLocked should queue");
+
+    drop(lost);
+
+    let mut replayed = 0;
+    recover_mirror_state_with(&mut |_| {
+        replayed += 1;
+        Ok(())
+    })
+    .expect("later fail-closed state should replay after a lost best-effort reply");
+    assert_eq!(replayed, 1);
+    assert!(!mirror_state_dirty(MirrorStateKind::Authorization));
+    assert!(ensure_mirror_state_recovered().is_ok());
+}
+
+#[test]
+fn missing_best_effort_reservation_preserves_system_success() {
+    let _guard = route_state_test_guard();
+    let mut reply = parcel::build_status_reply(&Status::from(StatusCode::Ok))
+        .expect("success reply should build");
+    let (data, data_size, offsets, offsets_size) = raw_parts(&mut reply);
+    let mut tr: binder_transaction_data = unsafe { std::mem::zeroed() };
+    tr.data.ptr.buffer = data as libc::c_ulong;
+    tr.data.ptr.offsets = offsets as libc::c_ulong;
+    tr.data_size = data_size;
+    tr.offsets_size = offsets_size;
+    let mut call = PendingAuthorizationCall {
+        request: ParsedAuthorizationRequest::AddAuthToken {
+            auth_token: Default::default(),
+        },
+        method: AuthorizationMethod::AddAuthToken,
+        caller: CallerInfo {
+            uid: 1000,
+            sid: String::new(),
+            pid: 2000,
+        },
+        mirror_update: None,
+    };
+
+    assert!(unsafe { build_authorization_reply_mirror(&tr, &mut call) }
+        .expect("best-effort mirror should preserve System success")
+        .is_none());
+    assert!(ensure_mirror_state_recovered().is_ok());
+}
+
+#[test]
 fn mirror_business_error_preserves_event_and_blocks_routes() {
     let _guard = route_state_test_guard();
-    reserve_mirror_update(MirrorStateKind::Maintenance)
-        .expect("onUserRemoved should reserve")
-        .enqueue(MirrorReplayEvent::Maintenance {
-            request: ParsedMaintenanceRequest::OnUserRemoved { user_id: 11 },
-            caller: CallerInfo {
-                uid: 1000,
-                sid: String::new(),
-                pid: 2000,
-            },
-        })
-        .expect("onUserRemoved should queue");
+    reserve_mirror_update(
+        MirrorStateKind::Maintenance,
+        MirrorFailurePolicy::FailClosed,
+    )
+    .expect("onUserRemoved should reserve")
+    .enqueue(MirrorReplayEvent::Maintenance {
+        request: ParsedMaintenanceRequest::OnUserRemoved { user_id: 11 },
+        caller: CallerInfo {
+            uid: 1000,
+            sid: String::new(),
+            pid: 2000,
+        },
+    })
+    .expect("onUserRemoved should queue");
 
     let error = recover_mirror_state_with(&mut |_| {
         Err(anyhow::Error::new(Status::new_service_specific_error(

--- a/injector/src/hook/rewrite/request.rs
+++ b/injector/src/hook/rewrite/request.rs
@@ -119,6 +119,7 @@ pub(in crate::hook) unsafe fn handle_br_transaction(
         );
 
         let requires_mirror = authorization_requires_mirror(&request);
+        let failure_policy = authorization_mirror_failure_policy(&request);
         let mut pending = PendingAuthorizationCall {
             request,
             method,
@@ -126,6 +127,13 @@ pub(in crate::hook) unsafe fn handle_br_transaction(
             mirror_update: None,
         };
         if requires_mirror && !expects_reply {
+            if failure_policy == MirrorFailurePolicy::BestEffort {
+                warn!(
+                    "event=mirror cannot confirm one-way best-effort authorization {:?} for uid={} pid={}; preserving System mutation without an OMK mirror",
+                    method, caller_uid, pending.caller.pid
+                );
+                return false;
+            }
             warn!(
                 "event=mirror cannot confirm one-way authorization {:?} for uid={} pid={}; blocking System mutation",
                 method, caller_uid, pending.caller.pid
@@ -134,8 +142,14 @@ pub(in crate::hook) unsafe fn handle_br_transaction(
             return true;
         }
         if requires_mirror {
-            match reserve_mirror_update(MirrorStateKind::Authorization) {
+            match reserve_mirror_update(MirrorStateKind::Authorization, failure_policy) {
                 Ok(reservation) => pending.mirror_update = Some(reservation),
+                Err(error) if failure_policy == MirrorFailurePolicy::BestEffort => {
+                    warn!(
+                        "event=mirror failed to reserve in-memory best-effort authorization {:?} update for uid={} pid={}: {:#}; preserving System mutation without an OMK mirror",
+                        method, caller_uid, pending.caller.pid, error
+                    );
+                }
                 Err(error) => {
                     warn!(
                         "event=mirror failed to reserve in-memory authorization {:?} update for uid={} pid={}: {:#}; blocking System mutation",
@@ -254,7 +268,10 @@ pub(in crate::hook) unsafe fn handle_br_transaction(
             return true;
         }
         if requires_mirror {
-            match reserve_mirror_update(MirrorStateKind::Maintenance) {
+            match reserve_mirror_update(
+                MirrorStateKind::Maintenance,
+                MirrorFailurePolicy::FailClosed,
+            ) {
                 Ok(reservation) => pending.mirror_update = Some(reservation),
                 Err(error) => {
                     warn!(

--- a/src/keymaster/authorization.rs
+++ b/src/keymaster/authorization.rs
@@ -310,10 +310,20 @@ impl AuthorizationManager {
             auth_token.timestamp.milliSeconds,
         );
         if auth_token.userId == 0 {
-            error!("Auth token has zero GK SID, indicating an authenticator problem");
+            if ctx.is_some() {
+                log::debug!(
+                    "mirrored auth token has zero GK SID, indicating an authenticator problem"
+                );
+            } else {
+                error!("Auth token has zero GK SID, indicating an authenticator problem");
+            }
         }
 
-        validate_auth_token_shape(auth_token)?;
+        // Android keystore2 accepts HAT contents at the addAuthToken ingestion boundary. Mirrored
+        // calls only arrive after System returned success, so preserve that result and attempt to
+        // localize the token without applying OMK-only shape or MAC checks. Direct service calls
+        // retain the stricter OMK boundary checks.
+        validate_auth_token_shape_for_source(ctx, auth_token)?;
         if should_skip_system_auth_token_verification(ctx) {
             log::debug!(
                 "system auth token MAC verification skipped for mirrored/config fallback authType={:#x} challengeTag={:04x}",
@@ -325,9 +335,11 @@ impl AuthorizationManager {
                 .context(ks_err!("system KeyMint did not verify the auth token MAC"))?;
         }
 
-        let localized = localize_auth_token_for_omk(auth_token)
-            .context(ks_err!("localizing trusted auth token for OMK"))?;
-        ENFORCEMENTS.add_auth_token(localized);
+        if let Some(localized) =
+            localize_auth_token_for_source(ctx, auth_token, localize_auth_token_for_omk)?
+        {
+            ENFORCEMENTS.add_auth_token(localized);
+        }
         Ok(())
     }
 
@@ -391,6 +403,36 @@ fn check_omk_keystore_permission(
     permission::check_keystore_permission(perm, Some(ctx))
         .context(label.to_string())
         .map_err(into_logged_binder)
+}
+
+fn validate_auth_token_shape_for_source(
+    ctx: Option<&CallerInfo>,
+    auth_token: &HardwareAuthToken,
+) -> Result<()> {
+    if ctx.is_some() {
+        Ok(())
+    } else {
+        validate_auth_token_shape(auth_token)
+    }
+}
+
+fn localize_auth_token_for_source(
+    ctx: Option<&CallerInfo>,
+    auth_token: &HardwareAuthToken,
+    localize: impl FnOnce(&HardwareAuthToken) -> Result<HardwareAuthToken>,
+) -> Result<Option<HardwareAuthToken>> {
+    match localize(auth_token).context(ks_err!("localizing trusted auth token for OMK")) {
+        Ok(localized) => Ok(Some(localized)),
+        Err(error) if ctx.is_some() => {
+            log::warn!(
+                "dropping auth token mirrored after System success because OMK localization failed authType={:#x} challengeTag={:04x}: {error:#}",
+                auth_token.authenticatorType.0,
+                challenge_tag(auth_token.challenge),
+            );
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn validate_auth_token_shape(auth_token: &HardwareAuthToken) -> Result<()> {
@@ -1016,5 +1058,164 @@ impl IOhMyAuthorizationService for AuthorizationManager {
         let sid = SecureUserId(secure_user_id);
         self.get_last_auth_time(sid, auth_types)
             .map_err(into_logged_binder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mirrored_caller() -> CallerInfo {
+        CallerInfo {
+            uid: 1000,
+            sid: "u:r:system_server:s0".to_string(),
+            pid: 2000,
+        }
+    }
+
+    fn valid_auth_token() -> HardwareAuthToken {
+        HardwareAuthToken {
+            challenge: 7,
+            userId: 11,
+            authenticatorId: 13,
+            authenticatorType: HardwareAuthenticatorType::PASSWORD,
+            mac: vec![0; AUTH_TOKEN_MAC_LEN],
+            ..Default::default()
+        }
+    }
+
+    fn combined_authenticator_type() -> HardwareAuthenticatorType {
+        HardwareAuthenticatorType(
+            HardwareAuthenticatorType::PASSWORD.0 | HardwareAuthenticatorType::FINGERPRINT.0,
+        )
+    }
+
+    #[test]
+    fn mirrored_auth_token_shapes_match_aosp_ingestion() {
+        let caller = mirrored_caller();
+        let mut variants = Vec::new();
+
+        let mut token = valid_auth_token();
+        token.mac.pop();
+        variants.push(("non-32-byte MAC", token));
+
+        variants.push((
+            "all-zero authorization fields",
+            HardwareAuthToken {
+                mac: vec![0; AUTH_TOKEN_MAC_LEN],
+                ..Default::default()
+            },
+        ));
+
+        let mut token = valid_auth_token();
+        token.userId = 0;
+        token.authenticatorId = 0;
+        token.timestamp.milliSeconds = 1;
+        variants.push(("zero SIDs with timestamp", token));
+
+        let mut token = valid_auth_token();
+        token.userId = 0;
+        token.authenticatorId = 0;
+        variants.push(("zero SIDs with challenge and auth type", token));
+
+        let mut token = valid_auth_token();
+        token.authenticatorType = HardwareAuthenticatorType::NONE;
+        variants.push(("nonzero SID with NONE", token));
+
+        let mut token = valid_auth_token();
+        token.authenticatorType = HardwareAuthenticatorType::ANY;
+        variants.push(("ANY authenticator type", token));
+
+        let mut token = valid_auth_token();
+        token.authenticatorType = combined_authenticator_type();
+        variants.push(("combined authenticator type", token));
+
+        let mut token = valid_auth_token();
+        token.authenticatorType = HardwareAuthenticatorType(4);
+        variants.push(("unknown authenticator type", token));
+
+        for (label, token) in variants {
+            assert!(
+                validate_auth_token_shape_for_source(Some(&caller), &token).is_ok(),
+                "mirror rejected {label}"
+            );
+        }
+    }
+
+    #[test]
+    fn direct_auth_token_shape_validation_remains_strict() {
+        assert!(validate_auth_token_shape_for_source(None, &valid_auth_token()).is_ok());
+
+        let mut combined = valid_auth_token();
+        combined.authenticatorType = combined_authenticator_type();
+        assert!(validate_auth_token_shape_for_source(None, &combined).is_ok());
+
+        let mut variants = Vec::new();
+
+        let mut token = valid_auth_token();
+        token.mac.pop();
+        variants.push(("non-32-byte MAC", token));
+
+        let mut token = valid_auth_token();
+        token.userId = 0;
+        token.authenticatorId = 0;
+        variants.push(("zero SIDs", token));
+
+        let mut token = valid_auth_token();
+        token.authenticatorType = HardwareAuthenticatorType::NONE;
+        variants.push(("NONE authenticator type", token));
+
+        let mut token = valid_auth_token();
+        token.authenticatorType = HardwareAuthenticatorType::ANY;
+        variants.push(("ANY authenticator type", token));
+
+        let mut token = valid_auth_token();
+        token.authenticatorType = HardwareAuthenticatorType(4);
+        variants.push(("unknown authenticator type", token));
+
+        for (label, token) in variants {
+            assert!(
+                validate_auth_token_shape_for_source(None, &token).is_err(),
+                "direct validation accepted {label}"
+            );
+        }
+    }
+
+    #[test]
+    fn mirrored_localization_failures_are_dropped() {
+        let caller = mirrored_caller();
+        let mut token = valid_auth_token();
+        token.authenticatorType = HardwareAuthenticatorType(4);
+
+        assert!(localize_auth_token_for_source(Some(&caller), &token, |token| {
+            token.to_km()?;
+            Ok(token.clone())
+        })
+        .expect("unknown mirror auth type should preserve System success")
+        .is_none());
+
+        let token = valid_auth_token();
+        assert!(localize_auth_token_for_source(Some(&caller), &token, |_| {
+            Err(anyhow::anyhow!("auth-token HMAC key is not initialized"))
+        })
+        .expect("unavailable mirror HMAC key should preserve System success")
+        .is_none());
+    }
+
+    #[test]
+    fn direct_localization_failures_are_propagated() {
+        assert!(localize_auth_token_for_source(None, &valid_auth_token(), |_| {
+            Err(anyhow::anyhow!("auth-token HMAC key is not initialized"))
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn combined_authenticator_type_is_rejected_by_wire_conversion() {
+        let mut token = valid_auth_token();
+        token.authenticatorType = combined_authenticator_type();
+
+        assert!(validate_auth_token_shape_for_source(None, &token).is_ok());
+        assert!(token.to_km().is_err());
     }
 }


### PR DESCRIPTION
## What changed and why?

Android 15 removed the strong-biometric guard from the non-BiometricPrompt `AuthenticationClient` path. On Android 15-17, a successful weak/convenience biometric authentication can therefore reach keystore with a HAT whose authorization fields are all zero. This is the observed trigger; it is not an Android 17-only ingestion change.

Separately, AOSP Android 12-17 keystore2 checks the caller permission at the `addAuthToken` ingestion boundary but does not validate HAT shape or MAC contents there. OMK's stricter mirror processing could reject an event after System had already returned success, poison the authorization recovery lane, and fail-close later OMK routes until restart.

This change aligns the trusted System-to-OMK mirror with those ingestion semantics while retaining strict direct OMK behavior:

- Trusted mirrored `AddAuthToken` calls skip OMK-only shape and System-MAC checks after System success.
- OMK still converts and re-signs a mirror token before caching it. If conversion, TEE wrapper acquisition, HMAC readiness, or HMAC generation fails, OMK logs and drops only that per-boot token while preserving System success.
- Direct `IKeystoreAuthorization.addAuthToken` calls keep strict shape validation, System HAT MAC verification, and propagated localization failures.
- Injector recovery classifies only `AddAuthToken` as best-effort. Reservation, lost-reply, publication, business-error, and OMK-unavailable failures drop that event without poisoning the lane; later events continue in global order.
- Device lock/unlock, user/storage state, expiry notifications, and maintenance mutations remain ordered and fail-closed.
- Representative server and injector regression tests cover the reviewed shape, conversion, HMAC-readiness, loss, ordering, and poison boundaries.

## Behavior and risk

- The trust boundary is unchanged: relaxed ingestion is reachable only through the existing caller-aware mirror path after a successful System call and the existing forwarded-caller/SELinux permission checks.
- Mirror correctness no longer depends on `mac.len() == 32`. AOSP `AuthTokenUtils.toHardwareAuthToken()` allocates a 32-byte MAC for Binder-reachable framework tokens, but no logcat HAT MAC capture was available in this environment.
- Successfully localized mirror tokens are re-signed with OMK's HMAC key before entering `ENFORCEMENTS`; an unlocalizable mirror token is never cached.
- Unknown open-enum authenticator values are therefore dropped on the trusted mirror while remaining errors for direct calls. The valid `PASSWORD | FINGERPRINT` bitmask value (`3`) is represented consistently in the wire/CDDL definitions.
- Losing one `AddAuthToken` event loses only replenishable per-boot cached authentication state; a later authentication supplies another token. Stateful authorization and maintenance events retain the existing fail-closed policy.
- Mirrored zero-SID diagnostics are debug-level to avoid false error alerts; direct zero-SID calls retain the error-level diagnostic.
- No routing configuration, database schema, or keyblob format is changed.

## Validation

- `git diff --check`: passed.
- `HardwareAuthenticatorType::PasswordOrFingerprint = 3` was manually confirmed aligned in the Rust wire definition and both CDDL definitions.
- The required Android Rust gate was **not run**: this environment has no `cargo`, `rustc`, `rustfmt`, Android Cargo target configuration, or BoringSSL build directory.
- Generated workspace tests were **not compiled or run on an aarch64 Android device**: `adb` and an authorized device are unavailable.
- No logcat HAT MAC-length capture was available. The implementation does not use MAC length as an acceptance condition.
- GitHub Actions `Build OhMyKeymint` run [31234131846](https://github.com/qwq233/OhMyKeymint/actions/runs/31234131846): BoringSSL, debug Android build, and release Android build all passed.

- [ ] The Android Rust gate passed, or this is a documentation-only change.
- [ ] All generated test binaries ran on an aarch64 Android device, or the
      reason this gate was not run is stated above.

## Checklist

- [x] I checked for and reused existing methods, helpers, abstractions,
      configuration, and utilities.
- [x] This pull request contains no unrelated changes or force-added ignored files.
- [x] I did not use `#[allow(...)]` only to silence Clippy.
- [x] I disclosed third-party material, its source, and its license, and kept all
      required notices.
- [x] I have read and agree to the copyright, concurrent-license, dispute
      authorization, and relicensing terms in
      [CONTRIBUTING.md](https://github.com/qwq233/OhMyKeymint/blob/master/docs/CONTRIBUTING.md).
