### PR TITLE
fix(keymint): prefer VINTF/system KeyMint version over Android fallback

### DIFF
--- a/src/plat/keymint_profile.rs
+++ b/src/plat/keymint_profile.rs
@@ -65,7 +65,8 @@ pub(crate) fn strongbox_keymint_present() -> bool {
 pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyMintHardwareProfile {
 	let version_number = match probe_keymint_version_from_vintf(security_level) {
 		Some(version) => {
-			log:: info!( "KeyMint version probe: VINTF probe succeeded, using VINTF version = {}",
+			log::info!(
+                "KeyMint version probe: VINTF probe succeeded, using VINTF version = {}",
                 version
             );
             version
@@ -77,18 +78,18 @@ pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyM
             match probe_system_keymint_hardware_info(security_level) {
                 Ok(info) => {
                     log::info!(
-                        "KeyMint version probe: system KeyMint getHardwareInfo() succeeded"
+                        "KeyMint version probe: system. KeyMint getHardwareInfo() succeeded"
                     );
                     log::info!(
                         "KeyMint version probe: system versionNumber = {}",
                         info.versionNumber
                     );
                     log::info!(
-                        "KeyMint version probe: system keyMintName = {: ?}",
+                        "KeyMint version probe: system keyMintName = {:?}",
                         info.keyMintName
                     );
                     log::info!(
-                        "KeyMint version probe: system keyMintAuthorName = {: ?}",
+                        "KeyMint version probe: system keyMintAuthorName = {:?}",
                         info.keyMintAuthorName
                     );
                     match normalize_keymint_version(info.versionNumber) {
@@ -101,7 +102,7 @@ pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyM
                         }
                         None => {
                             log::warn!(
-                                "KeyMint version probe: system KeyMint returned invalid versionNumber = {}, falling back to KEYMINT_V1 = {}",
+                                "KeyMint version probe: system. KeyMint returned invalid versionNumber = {}, falling back to KEYMINT_V1 = {}",
                                 info.versionNumber,
                                 KEYMINT_V1
                             );
@@ -111,11 +112,11 @@ pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyM
                 }
                 Err(error) => {
                     log::warn!(
-                        "KeyMint version probe: system KeyMint getHardwareInfo() failed: {: #}",
+                        "KeyMint version probe: system. KeyMint getHardwareInfo() failed: {:#}",
                         error
                     );
                     log::warn!(
-                        "KeyMint version probe: VINTF and system KeyMint probes both failed, falling back to KEYMINT_V1 = {}",
+                        "KeyMint version probe: VINTF and system. KeyMint probes both failed, falling back to KEYMINT_V1 = {}",
                         KEYMINT_V1
                     );
                     KEYMINT_V1
@@ -150,7 +151,8 @@ pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyM
 
         Err(error) => {
             log::warn!(
-                "failed to resolve dynamic KeyMint hardware profile: {error: #}" );
+                "failed to resolve dynamic KeyMint hardware profile: {error:#}"
+            );
 			fallback_profile( security_level, version_number, )
 		}
 	}

--- a/src/plat/keymint_profile.rs
+++ b/src/plat/keymint_profile.rs
@@ -66,123 +66,101 @@ pub(crate) fn resolve_hardware_profile(
     security_level: SecurityLevel,
 ) -> KeyMintHardwareProfile {
     /*
-     * KeyMint versionNumber 是具体 KeyMint 实现返回的版本号。
+     * KeyMint version 探测优先级：
      *
-     * 不允许通过 Android 版本推导 KeyMint versionNumber。
+     * 1. VINTF
+     * 2. System KeyMint getHardwareInfo()
+     * 3. KEYMINT_V1 兜底
      *
-     * 优先级：
-     *
-     * 1. 原始系统 KeyMint:
-     *      IKeyMintDevice::getHardwareInfo().versionNumber
-     *
-     * 2. VINTF KeyMint 版本：
-     *      仅作为系统 KeyMint 无法访问时的备用来源
-     *
-     * 3. KEYMINT_V1：
-     *      最终兼容性兜底，不能视为真实检测结果
+     * 注意：
+     * VINTF 的结果优先于 System KeyMint。
+     * System KeyMint 的 versionNumber 不应该在 VINTF
+     * 已经成功解析后覆盖 VINTF 的结果。
      */
 
-    let system_keymint_info =
-        match probe_system_keymint_hardware_info(security_level) {
-            Ok(info) => {
-                log::info!(
-                    "KeyMint version probe: system KeyMint getHardwareInfo() succeeded"
-                );
-
-                log::info!(
-                    "KeyMint version probe: system versionNumber={}",
-                    info.versionNumber
-                );
-
-                log::info!(
-                    "KeyMint version probe: system keyMintName={:?}",
-                    info.keyMintName
-                );
-
-                log::info!(
-                    "KeyMint version probe: system keyMintAuthorName={:?}",
-                    info.keyMintAuthorName
-                );
-
-                Some(info)
-            }
-
-            Err(error) => {
-                log::warn!(
-                    "KeyMint version probe: system KeyMint getHardwareInfo() failed: {:#}",
-                    error
-                );
-
-                None
-            }
-        };
-
-    /*
-     * 优先使用原始系统 KeyMint 返回的 versionNumber。
-     */
-    let version_number = if let Some(ref info) = system_keymint_info {
-        match normalize_keymint_version(info.versionNumber) {
-            Some(version) => {
-                log::info!(
-                    "KeyMint version probe: using system KeyMint versionNumber={}",
-                    version
-                );
-
+    let version_number = match probe_keymint_version_from_vintf(security_level) {
+        Some(version) => {
+            log::info!(
+                "KeyMint version probe: VINTF probe succeeded, \
+                 using VINTF version={}",
                 version
-            }
+            );
 
-            None => {
-                log::warn!(
-                    "KeyMint version probe: system KeyMint returned invalid \
-                     versionNumber={}, trying VINTF",
-                    info.versionNumber
-                );
+            version
+        }
 
-                match probe_keymint_version_from_vintf(security_level) {
-                    Some(version) => {
-                        log::info!(
-                            "KeyMint version probe: using VINTF version={}",
+        None => {
+            log::warn!(
+                "KeyMint version probe: VINTF probe failed, \
+                 trying system KeyMint getHardwareInfo()"
+            );
+
+            match probe_system_keymint_hardware_info(security_level) {
+                Ok(info) => {
+                    log::info!(
+                        "KeyMint version probe: system KeyMint \
+                         getHardwareInfo() succeeded"
+                    );
+
+                    log::info!(
+                        "KeyMint version probe: system \
+                         versionNumber={}",
+                        info.versionNumber
+                    );
+
+                    log::info!(
+                        "KeyMint version probe: system \
+                         keyMintName={:?}",
+                        info.keyMintName
+                    );
+
+                    log::info!(
+                        "KeyMint version probe: system \
+                         keyMintAuthorName={:?}",
+                        info.keyMintAuthorName
+                    );
+
+                    match normalize_keymint_version(info.versionNumber) {
+                        Some(version) => {
+                            log::info!(
+                                "KeyMint version probe: using system \
+                                 KeyMint versionNumber={}",
+                                version
+                            );
+
                             version
-                        );
+                        }
 
-                        version
-                    }
+                        None => {
+                            log::warn!(
+                                "KeyMint version probe: system KeyMint \
+                                 returned invalid versionNumber={}, \
+                                 falling back to KEYMINT_V1={}",
+                                info.versionNumber,
+                                KEYMINT_V1
+                            );
 
-                    None => {
-                        log::warn!(
-                            "KeyMint version probe: system versionNumber is invalid \
-                             and VINTF probe failed; using fallback KEYMINT_V1={}",
                             KEYMINT_V1
-                        );
-
-                        KEYMINT_V1
+                        }
                     }
                 }
-            }
-        }
-    } else {
-        /*
-         * 系统 KeyMint 无法访问时才尝试 VINTF。
-         */
-        match probe_keymint_version_from_vintf(security_level) {
-            Some(version) => {
-                log::info!(
-                    "KeyMint version probe: system KeyMint probe failed, \
-                     using VINTF version={}",
-                    version
-                );
 
-                version
-            }
+                Err(error) => {
+                    log::warn!(
+                        "KeyMint version probe: system KeyMint \
+                         getHardwareInfo() failed: {:#}",
+                        error
+                    );
 
-            None => {
-                log::warn!(
-                    "KeyMint version probe: system KeyMint probe and VINTF probe \
-                     both failed; using fallback KEYMINT_V1={}",
+                    log::warn!(
+                        "KeyMint version probe: VINTF and system \
+                         KeyMint probes both failed, \
+                         falling back to KEYMINT_V1={}",
+                        KEYMINT_V1
+                    );
+
                     KEYMINT_V1
-                );
-
-                KEYMINT_V1
+                }
             }
         }
     };
@@ -192,80 +170,36 @@ pub(crate) fn resolve_hardware_profile(
         version_number
     );
 
-    /*
-     * 属性配置优先。
-     *
-     * 注意这里使用的仍然是上面已经确定的 version_number，
-     * 不重新探测 KeyMint。
-     */
     if let Some(profile) = resolve_property_profile_with(
         security_level,
         version_number,
         resetprop::read_string_property,
     ) {
-        log::info!(
-            "KeyMint hardware profile: resolved from properties, \
-             version_number={}",
-            version_number
-        );
-
         return profile;
     }
 
-    /*
-     * 如果系统 KeyMint getHardwareInfo() 成功，
-     * 直接复用第一次获取到的 HardwareInfo。
-     *
-     * 不再重复调用 probe_system_keymint_hardware_info()。
-     */
-    if let Some(ref info) = system_keymint_info {
-        match profile_from_system_hardware_info(
-            info,
-            security_level,
-            version_number,
-        ) {
-            Ok(profile) => {
-                log::info!(
-                    "KeyMint hardware profile: resolved from system KeyMint, \
-                     version_number={}",
-                    version_number
-                );
+    match probe_system_keymint_hardware_info(security_level)
+        .and_then(|info| {
+            profile_from_system_hardware_info(
+                &info,
+                security_level,
+                version_number,
+            )
+        })
+    {
+        Ok(profile) => profile,
 
-                return profile;
-            }
+        Err(error) => {
+            log::warn!(
+                "failed to resolve dynamic KeyMint hardware profile: {error:#}"
+            );
 
-            Err(error) => {
-                log::warn!(
-                    "KeyMint hardware profile: failed to build profile from \
-                     system KeyMint hardware info: {:#}",
-                    error
-                );
-            }
+            fallback_profile(
+                security_level,
+                version_number,
+            )
         }
-    } else {
-        log::warn!(
-            "KeyMint hardware profile: system KeyMint hardware info is unavailable"
-        );
     }
-
-    /*
-     * 最终 fallback。
-     *
-     * 此时 version_number 已经确定：
-     *   - system KeyMint 成功 -> 使用 system versionNumber
-     *   - system 失败但 VINTF 成功 -> 使用 VINTF
-     *   - 两者都失败 -> KEYMINT_V1
-     */
-    log::warn!(
-        "KeyMint hardware profile: using fallback profile, \
-         version_number={}",
-        version_number
-    );
-
-    fallback_profile(
-        security_level,
-        version_number,
-    )
 }
 
 fn detect_strongbox_keymint_present() -> bool {

--- a/src/plat/keymint_profile.rs
+++ b/src/plat/keymint_profile.rs
@@ -34,32 +34,238 @@ pub(crate) fn strongbox_keymint_present() -> bool {
     *STRONGBOX_PRESENT.get_or_init(detect_strongbox_keymint_present)
 }
 
-pub(crate) fn resolve_hardware_profile(security_level: SecurityLevel) -> KeyMintHardwareProfile {
-    let version_number = probe_keymint_version_from_vintf(security_level)
-        .or_else(|| {
-            probe_system_keymint_hardware_info(security_level)
-                .ok()
-                .and_then(|info| normalize_keymint_version(info.versionNumber))
-        })
-        .unwrap_or(KEYMINT_V1);
+// pub(crate) fn resolve_hardware_profile(security_level: SecurityLevel) -> KeyMintHardwareProfile {
+    // let version_number = probe_keymint_version_from_vintf(security_level)
+        // .or_else(|| {
+            // probe_system_keymint_hardware_info(security_level)
+                // .ok()
+                // .and_then(|info| normalize_keymint_version(info.versionNumber))
+        // })
+        // .unwrap_or(KEYMINT_V1);
 
+    // if let Some(profile) = resolve_property_profile_with(
+        // security_level,
+        // version_number,
+        // resetprop::read_string_property,
+    // ) {
+        // return profile;
+    // }
+
+    // match probe_system_keymint_hardware_info(security_level)
+        // .and_then(|info| profile_from_system_hardware_info(&info, security_level, version_number))
+    // {
+        // Ok(profile) => profile,
+        // Err(error) => {
+            // log::warn!("failed to resolve dynamic KeyMint hardware profile: {error:#}");
+            // fallback_profile(security_level, version_number)
+        // }
+    // }
+// }
+
+pub(crate) fn resolve_hardware_profile(
+    security_level: SecurityLevel,
+) -> KeyMintHardwareProfile {
+    /*
+     * KeyMint versionNumber 是具体 KeyMint 实现返回的版本号。
+     *
+     * 不允许通过 Android 版本推导 KeyMint versionNumber。
+     *
+     * 优先级：
+     *
+     * 1. 原始系统 KeyMint:
+     *      IKeyMintDevice::getHardwareInfo().versionNumber
+     *
+     * 2. VINTF KeyMint 版本：
+     *      仅作为系统 KeyMint 无法访问时的备用来源
+     *
+     * 3. KEYMINT_V1：
+     *      最终兼容性兜底，不能视为真实检测结果
+     */
+
+    let system_keymint_info =
+        match probe_system_keymint_hardware_info(security_level) {
+            Ok(info) => {
+                log::info!(
+                    "KeyMint version probe: system KeyMint getHardwareInfo() succeeded"
+                );
+
+                log::info!(
+                    "KeyMint version probe: system versionNumber={}",
+                    info.versionNumber
+                );
+
+                log::info!(
+                    "KeyMint version probe: system keyMintName={:?}",
+                    info.keyMintName
+                );
+
+                log::info!(
+                    "KeyMint version probe: system keyMintAuthorName={:?}",
+                    info.keyMintAuthorName
+                );
+
+                Some(info)
+            }
+
+            Err(error) => {
+                log::warn!(
+                    "KeyMint version probe: system KeyMint getHardwareInfo() failed: {:#}",
+                    error
+                );
+
+                None
+            }
+        };
+
+    /*
+     * 优先使用原始系统 KeyMint 返回的 versionNumber。
+     */
+    let version_number = if let Some(ref info) = system_keymint_info {
+        match normalize_keymint_version(info.versionNumber) {
+            Some(version) => {
+                log::info!(
+                    "KeyMint version probe: using system KeyMint versionNumber={}",
+                    version
+                );
+
+                version
+            }
+
+            None => {
+                log::warn!(
+                    "KeyMint version probe: system KeyMint returned invalid \
+                     versionNumber={}, trying VINTF",
+                    info.versionNumber
+                );
+
+                match probe_keymint_version_from_vintf(security_level) {
+                    Some(version) => {
+                        log::info!(
+                            "KeyMint version probe: using VINTF version={}",
+                            version
+                        );
+
+                        version
+                    }
+
+                    None => {
+                        log::warn!(
+                            "KeyMint version probe: system versionNumber is invalid \
+                             and VINTF probe failed; using fallback KEYMINT_V1={}",
+                            KEYMINT_V1
+                        );
+
+                        KEYMINT_V1
+                    }
+                }
+            }
+        }
+    } else {
+        /*
+         * 系统 KeyMint 无法访问时才尝试 VINTF。
+         */
+        match probe_keymint_version_from_vintf(security_level) {
+            Some(version) => {
+                log::info!(
+                    "KeyMint version probe: system KeyMint probe failed, \
+                     using VINTF version={}",
+                    version
+                );
+
+                version
+            }
+
+            None => {
+                log::warn!(
+                    "KeyMint version probe: system KeyMint probe and VINTF probe \
+                     both failed; using fallback KEYMINT_V1={}",
+                    KEYMINT_V1
+                );
+
+                KEYMINT_V1
+            }
+        }
+    };
+
+    log::info!(
+        "KeyMint version probe: final version_number={}",
+        version_number
+    );
+
+    /*
+     * 属性配置优先。
+     *
+     * 注意这里使用的仍然是上面已经确定的 version_number，
+     * 不重新探测 KeyMint。
+     */
     if let Some(profile) = resolve_property_profile_with(
         security_level,
         version_number,
         resetprop::read_string_property,
     ) {
+        log::info!(
+            "KeyMint hardware profile: resolved from properties, \
+             version_number={}",
+            version_number
+        );
+
         return profile;
     }
 
-    match probe_system_keymint_hardware_info(security_level)
-        .and_then(|info| profile_from_system_hardware_info(&info, security_level, version_number))
-    {
-        Ok(profile) => profile,
-        Err(error) => {
-            log::warn!("failed to resolve dynamic KeyMint hardware profile: {error:#}");
-            fallback_profile(security_level, version_number)
+    /*
+     * 如果系统 KeyMint getHardwareInfo() 成功，
+     * 直接复用第一次获取到的 HardwareInfo。
+     *
+     * 不再重复调用 probe_system_keymint_hardware_info()。
+     */
+    if let Some(ref info) = system_keymint_info {
+        match profile_from_system_hardware_info(
+            info,
+            security_level,
+            version_number,
+        ) {
+            Ok(profile) => {
+                log::info!(
+                    "KeyMint hardware profile: resolved from system KeyMint, \
+                     version_number={}",
+                    version_number
+                );
+
+                return profile;
+            }
+
+            Err(error) => {
+                log::warn!(
+                    "KeyMint hardware profile: failed to build profile from \
+                     system KeyMint hardware info: {:#}",
+                    error
+                );
+            }
         }
+    } else {
+        log::warn!(
+            "KeyMint hardware profile: system KeyMint hardware info is unavailable"
+        );
     }
+
+    /*
+     * 最终 fallback。
+     *
+     * 此时 version_number 已经确定：
+     *   - system KeyMint 成功 -> 使用 system versionNumber
+     *   - system 失败但 VINTF 成功 -> 使用 VINTF
+     *   - 两者都失败 -> KEYMINT_V1
+     */
+    log::warn!(
+        "KeyMint hardware profile: using fallback profile, \
+         version_number={}",
+        version_number
+    );
+
+    fallback_profile(
+        security_level,
+        version_number,
+    )
 }
 
 fn detect_strongbox_keymint_present() -> bool {

--- a/src/plat/keymint_profile.rs
+++ b/src/plat/keymint_profile.rs
@@ -62,103 +62,62 @@ pub(crate) fn strongbox_keymint_present() -> bool {
     // }
 // }
 
-pub(crate) fn resolve_hardware_profile(
-    security_level: SecurityLevel,
-) -> KeyMintHardwareProfile {
-    /*
-     * KeyMint version 探测优先级：
-     *
-     * 1. VINTF
-     * 2. System KeyMint getHardwareInfo()
-     * 3. KEYMINT_V1 兜底
-     *
-     * 注意：
-     * VINTF 的结果优先于 System KeyMint。
-     * System KeyMint 的 versionNumber 不应该在 VINTF
-     * 已经成功解析后覆盖 VINTF 的结果。
-     */
-
-    let version_number = match probe_keymint_version_from_vintf(security_level) {
-        Some(version) => {
-            log::info!(
-                "KeyMint version probe: VINTF probe succeeded, \
-                 using VINTF version={}",
+pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyMintHardwareProfile {
+	let version_number = match probe_keymint_version_from_vintf(security_level) {
+		Some(version) => {
+			log:: info!( "KeyMint version probe: VINTF probe succeeded, using VINTF version = {}",
                 version
             );
-
             version
         }
-
         None => {
             log::warn!(
-                "KeyMint version probe: VINTF probe failed, \
-                 trying system KeyMint getHardwareInfo()"
+                "KeyMint version probe: VINTF probe failed, trying system KeyMint getHardwareInfo()"
             );
-
             match probe_system_keymint_hardware_info(security_level) {
                 Ok(info) => {
                     log::info!(
-                        "KeyMint version probe: system KeyMint \
-                         getHardwareInfo() succeeded"
+                        "KeyMint version probe: system KeyMint getHardwareInfo() succeeded"
                     );
-
                     log::info!(
-                        "KeyMint version probe: system \
-                         versionNumber={}",
+                        "KeyMint version probe: system versionNumber = {}",
                         info.versionNumber
                     );
-
                     log::info!(
-                        "KeyMint version probe: system \
-                         keyMintName={:?}",
+                        "KeyMint version probe: system keyMintName = {: ?}",
                         info.keyMintName
                     );
-
                     log::info!(
-                        "KeyMint version probe: system \
-                         keyMintAuthorName={:?}",
+                        "KeyMint version probe: system keyMintAuthorName = {: ?}",
                         info.keyMintAuthorName
                     );
-
                     match normalize_keymint_version(info.versionNumber) {
                         Some(version) => {
                             log::info!(
-                                "KeyMint version probe: using system \
-                                 KeyMint versionNumber={}",
+                                "KeyMint version probe: using system KeyMint versionNumber = {}",
                                 version
                             );
-
                             version
                         }
-
                         None => {
                             log::warn!(
-                                "KeyMint version probe: system KeyMint \
-                                 returned invalid versionNumber={}, \
-                                 falling back to KEYMINT_V1={}",
+                                "KeyMint version probe: system KeyMint returned invalid versionNumber = {}, falling back to KEYMINT_V1 = {}",
                                 info.versionNumber,
                                 KEYMINT_V1
                             );
-
                             KEYMINT_V1
                         }
                     }
                 }
-
                 Err(error) => {
                     log::warn!(
-                        "KeyMint version probe: system KeyMint \
-                         getHardwareInfo() failed: {:#}",
+                        "KeyMint version probe: system KeyMint getHardwareInfo() failed: {: #}",
                         error
                     );
-
                     log::warn!(
-                        "KeyMint version probe: VINTF and system \
-                         KeyMint probes both failed, \
-                         falling back to KEYMINT_V1={}",
+                        "KeyMint version probe: VINTF and system KeyMint probes both failed, falling back to KEYMINT_V1 = {}",
                         KEYMINT_V1
                     );
-
                     KEYMINT_V1
                 }
             }
@@ -166,7 +125,7 @@ pub(crate) fn resolve_hardware_profile(
     };
 
     log::info!(
-        "KeyMint version probe: final version_number={}",
+        "KeyMint version probe: final version_number = {}",
         version_number
     );
 
@@ -191,15 +150,10 @@ pub(crate) fn resolve_hardware_profile(
 
         Err(error) => {
             log::warn!(
-                "failed to resolve dynamic KeyMint hardware profile: {error:#}"
-            );
-
-            fallback_profile(
-                security_level,
-                version_number,
-            )
-        }
-    }
+                "failed to resolve dynamic KeyMint hardware profile: {error: #}" );
+			fallback_profile( security_level, version_number, )
+		}
+	}
 }
 
 fn detect_strongbox_keymint_present() -> bool {

--- a/src/plat/keymint_profile.rs
+++ b/src/plat/keymint_profile.rs
@@ -34,38 +34,12 @@ pub(crate) fn strongbox_keymint_present() -> bool {
     *STRONGBOX_PRESENT.get_or_init(detect_strongbox_keymint_present)
 }
 
-// pub(crate) fn resolve_hardware_profile(security_level: SecurityLevel) -> KeyMintHardwareProfile {
-    // let version_number = probe_keymint_version_from_vintf(security_level)
-        // .or_else(|| {
-            // probe_system_keymint_hardware_info(security_level)
-                // .ok()
-                // .and_then(|info| normalize_keymint_version(info.versionNumber))
-        // })
-        // .unwrap_or(KEYMINT_V1);
-
-    // if let Some(profile) = resolve_property_profile_with(
-        // security_level,
-        // version_number,
-        // resetprop::read_string_property,
-    // ) {
-        // return profile;
-    // }
-
-    // match probe_system_keymint_hardware_info(security_level)
-        // .and_then(|info| profile_from_system_hardware_info(&info, security_level, version_number))
-    // {
-        // Ok(profile) => profile,
-        // Err(error) => {
-            // log::warn!("failed to resolve dynamic KeyMint hardware profile: {error:#}");
-            // fallback_profile(security_level, version_number)
-        // }
-    // }
-// }
-
-pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyMintHardwareProfile {
-	let version_number = match probe_keymint_version_from_vintf(security_level) {
-		Some(version) => {
-			log::info!(
+pub(crate) fn resolve_hardware_profile(
+    security_level: SecurityLevel,
+) -> KeyMintHardwareProfile {
+    let version_number = match probe_keymint_version_from_vintf(security_level) {
+        Some(version) => {
+            log::info!(
                 "KeyMint version probe: VINTF probe succeeded, using VINTF version = {}",
                 version
             );
@@ -73,12 +47,14 @@ pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyM
         }
         None => {
             log::warn!(
-                "KeyMint version probe: VINTF probe failed, trying system KeyMint getHardwareInfo()"
+                "KeyMint version probe: VINTF probe failed, \
+                 trying system KeyMint getHardwareInfo()"
             );
+
             match probe_system_keymint_hardware_info(security_level) {
                 Ok(info) => {
                     log::info!(
-                        "KeyMint version probe: system. KeyMint getHardwareInfo() succeeded"
+                        "KeyMint version probe: system KeyMint getHardwareInfo() succeeded"
                     );
                     log::info!(
                         "KeyMint version probe: system versionNumber = {}",
@@ -92,6 +68,7 @@ pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyM
                         "KeyMint version probe: system keyMintAuthorName = {:?}",
                         info.keyMintAuthorName
                     );
+
                     match normalize_keymint_version(info.versionNumber) {
                         Some(version) => {
                             log::info!(
@@ -102,7 +79,9 @@ pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyM
                         }
                         None => {
                             log::warn!(
-                                "KeyMint version probe: system. KeyMint returned invalid versionNumber = {}, falling back to KEYMINT_V1 = {}",
+                                "KeyMint version probe: system KeyMint returned \
+                                 invalid versionNumber = {}, falling back to \
+                                 KEYMINT_V1 = {}",
                                 info.versionNumber,
                                 KEYMINT_V1
                             );
@@ -112,11 +91,12 @@ pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyM
                 }
                 Err(error) => {
                     log::warn!(
-                        "KeyMint version probe: system. KeyMint getHardwareInfo() failed: {:#}",
-                        error
+                        "KeyMint version probe: system KeyMint getHardwareInfo() \
+                         failed: {error:#}"
                     );
                     log::warn!(
-                        "KeyMint version probe: VINTF and system. KeyMint probes both failed, falling back to KEYMINT_V1 = {}",
+                        "KeyMint version probe: VINTF and system KeyMint probes \
+                         both failed, falling back to KEYMINT_V1 = {}",
                         KEYMINT_V1
                     );
                     KEYMINT_V1
@@ -138,24 +118,15 @@ pub(crate) fn resolve_hardware_profile( security_level: SecurityLevel, ) -> KeyM
         return profile;
     }
 
-    match probe_system_keymint_hardware_info(security_level)
-        .and_then(|info| {
-            profile_from_system_hardware_info(
-                &info,
-                security_level,
-                version_number,
-            )
-        })
-    {
+    match probe_system_keymint_hardware_info(security_level).and_then(|info| {
+        profile_from_system_hardware_info(&info, security_level, version_number)
+    }) {
         Ok(profile) => profile,
-
         Err(error) => {
-            log::warn!(
-                "failed to resolve dynamic KeyMint hardware profile: {error:#}"
-            );
-			fallback_profile( security_level, version_number, )
-		}
-	}
+            log::warn!("failed to resolve dynamic KeyMint hardware profile: {error:#}");
+            fallback_profile(security_level, version_number)
+        }
+    }
 }
 
 fn detect_strongbox_keymint_present() -> bool {

--- a/src/plat/keymint_profile.rs
+++ b/src/plat/keymint_profile.rs
@@ -36,7 +36,12 @@ pub(crate) fn strongbox_keymint_present() -> bool {
 
 pub(crate) fn resolve_hardware_profile(security_level: SecurityLevel) -> KeyMintHardwareProfile {
     let version_number = probe_keymint_version_from_vintf(security_level)
-        .unwrap_or_else(fallback_keymint_version_from_android);
+        .or_else(|| {
+            probe_system_keymint_hardware_info(security_level)
+                .ok()
+                .and_then(|info| normalize_keymint_version(info.versionNumber))
+        })
+        .unwrap_or(KEYMINT_V1);
 
     if let Some(profile) = resolve_property_profile_with(
         security_level,
@@ -265,17 +270,6 @@ fn keymint_instance_declared_in_vintf(security_level: SecurityLevel) -> bool {
             log::warn!("failed to resolve KeyMint instance from VINTF: {error:#}");
             false
         }
-    }
-}
-
-fn fallback_keymint_version_from_android() -> i32 {
-    match kmr_common::android_version::android_major_version() {
-        Some(version) if version >= 17 => KEYMINT_V5,
-        Some(16) => KEYMINT_V4,
-        Some(14 | 15) => KEYMINT_V3,
-        Some(13) => KEYMINT_V2,
-        Some(12) => KEYMINT_V1,
-        _ => KEYMINT_V4,
     }
 }
 


### PR DESCRIPTION
Problem:
On some OEM devices (e.g. Xiaomi HyperOS Android 16), the device VINTF declares android.hardware.security.keymint/IKeyMintDevice/default@1 (KeyMint 1.0 / 100), but OMK fell back to KEYMINT_V4 (400) based on the Android major version. Detectors such as Duck Detector then report a VINTF vs attestation version mismatch.

Root cause:
resolve_hardware_profile() used
probe_keymint_version_from_vintf().unwrap_or_else(fallback_keymint_version_from_android). When the VINTF probe failed or was inconclusive, the Android-version mapping overrode the device's real HAL declaration.

Change:
- Prefer the VINTF AIDL version when available.
- Otherwise use the system KeyMint getHardwareInfo().versionNumber (normalized).
- Only if both probes fail, fall back to KEYMINT_V1 (100).
- Remove reliance on Android major version to invent a KeyMint version.